### PR TITLE
Bump Ember CLI to 2.14.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: 'module'
   },
   extends: 'eslint:recommended',

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
+yarn-error.log
 testem.log
 
 .env.deploy.*
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ node_js:
 sudo: false
 
 cache:
-  directories:
-    - $HOME/.npm
-    - $HOME/.cache # includes bowers cache
+  yarn: true
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
@@ -24,14 +22,13 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
-  - bower --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add phantomjs-prebuilt
   - phantomjs --version
 
 install:
-  - npm install
-  - bower install
+  - yarn install --no-lockfile --non-interactive
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,10 @@
 /* eslint-env node */
+'use strict';
+
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/package.json
+++ b/package.json
@@ -25,42 +25,41 @@
   },
   "dependencies": {
     "ember-basic-dropdown": "^0.32.0",
-    "ember-cli-babel": "^6.0.0",
-    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-babel": "^6.3.0",
+    "ember-cli-htmlbars": "^2.0.1",
     "ember-power-calendar": "^0.4.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "^2.4.1",
+    "ember-ajax": "^3.0.0",
     "ember-assign-helper": "0.1.2",
-    "ember-cli": "^2.12.0-beta.1",
+    "ember-cli": "~2.14.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-bootstrap-sassy": "^0.5.5",
     "ember-cli-custom-assertions": "0.0.7",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-deploy": "^0.5.1",
     "ember-cli-eslint": "^3.0.2",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^3.1.0",
+    "ember-cli-qunit": "^4.0.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "6.1.1",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "2.0.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.6.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
     "ember-pagefront": "0.11.2",
     "ember-resolver": "^4.1.0",
-    "ember-source": "^2.12.1",
+    "ember-source": "~2.14.0",
     "ember-truth-helpers": "^1.3.0",
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,12 @@
 /* eslint-env node */
 module.exports = {
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'PhantomJS'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
+  launch_in_dev: [
+    'PhantomJS',
+    'Chrome'
   ]
 };

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -5,8 +5,6 @@ import config from './config/environment';
 
 let App;
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,10 @@
 /* eslint-env node */
+'use strict';
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
-    environment: environment,
+    environment,
     rootURL: '/',
     locationType: 'auto',
     moment: {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,0 +1,9 @@
+/* eslint-env node */
+module.exports = {
+  browsers: [
+    'ie 9',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
+  ]
+};

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -17,7 +17,7 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,7 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
+start();


### PR DESCRIPTION
In trying to track down a bug, I noticed that I could no longer build the "ember-beta" scenario. I've upgraded Ember CLI as part of resolving this problem. I pretty much blindly followed the upgrade instructions, please let me know if I can tweak this at all to suit your tastes and/or needs.

Relatedly, this will fail with ember-beta! This is good for me (see above), but not so good for this pull request.