### PR TITLE
Add initiallyOpened to basic-dropdown

### DIFF
--- a/addon/templates/components/power-datepicker.hbs
+++ b/addon/templates/components/power-datepicker.hbs
@@ -4,6 +4,7 @@
   onClose=onClose
   onFocus=onFocus
   destination=destination
+  initiallyOpened=initiallyOpened
   horizontalPosition=horizontalPosition
   verticalPosition=verticalPosition
   renderInPlace=renderInPlace


### PR DESCRIPTION
Adding `initiallyOpened` to basic-dropdown as it was missing, could not open the datepicker by default.