### PR TITLE
Add calculatePosition to ember-basic-dropdown

### DIFF
--- a/addon/templates/components/power-datepicker.hbs
+++ b/addon/templates/components/power-datepicker.hbs
@@ -6,6 +6,7 @@
   destination=destination
   initiallyOpened=initiallyOpened
   horizontalPosition=horizontalPosition
+  calculatePosition=calculatePosition
   verticalPosition=verticalPosition
   renderInPlace=renderInPlace
   as |dd|}}


### PR DESCRIPTION
I noticed that I could not change the position of the datepicker because we don't pass the `calculatePosition` to `ember-basic-dropdown`. This fixes my issue. I have tested it locally