### PR TITLE
Remove ember-native-dom-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "ember-basic-dropdown": "^1.1.2",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-native-dom-helpers": "^0.5.10",
     "ember-power-calendar": "^0.12.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,7 +2065,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -3794,13 +3794,6 @@ ember-maybe-in-element@^0.2.0:
   integrity sha512-R5e6N8yDbfNbA/3lMZsFs2KEzv/jt80TsATiKMCqdqKuSG82KrD25cRdU5VkaE8dTQbziyBeuJs90bBiqOnakQ==
   dependencies:
     ember-cli-babel "^7.1.0"
-
-ember-native-dom-helpers@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.6.0"
 
 ember-power-calendar-moment@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
It seems they're not used.

As a sidenote: ember-native-dom-helpers is causing an error to be thrown in an upstream project of mine:

```
TypeError: checker.exists is not a function

    at Class._emberStringDependencyPresent (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:372:20)
    at Class._getEmberModulesAPIBlacklist (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:358:14)
    at Class._getEmberModulesAPIPolyfill (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:262:30)
    at Class._getBabelOptions (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:211:12)
    at Class.buildBabelOptions (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:36:17)
    at Class.transpileTree (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:52:58)
    at Object.toTree (/home/vagrant/project/node_modules/ember-native-dom-helpers/node_modules/ember-cli-babel/index.js:61:30
    at /home/vagrant/student/node_modules/ember-cli-preprocess-registry/preprocessors.js:180:26
    at Array.forEach (<anonymous>:null:null)
    at processPlugins (/home/vagrant/student/node_modules/ember-cli-preprocess-registry/preprocessors.js:178:11)
    at Function.module.exports.preprocessJs (/home/vagrant/student/node_modules/ember-cli-preprocess-registry/preprocessors.js:171:10)
    at Class.preprocessJs (/home/vagrant/student/node_modules/ember-cli/lib/models/addon.js:1309:25)
    at Class.treeForAddonTestSupport (/home/vagrant/project/node_modules/ember-native-dom-helpers/index.js:20:17)
```