### PR TITLE
Make ember-power-calendar-moment a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-native-dom-helpers": "^0.5.10",
-    "ember-power-calendar": "^0.12.0"
+    "ember-power-calendar": "^0.12.0",
+    "ember-power-calendar-moment": "^0.1.6"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
@@ -54,7 +55,6 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-power-calendar-moment": "^0.1.6",
     "ember-qunit": "^3.4.1",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.9.0",


### PR DESCRIPTION
When using this addon within another addon, and then using _that_ addon in an Ember app, we get the following error:
```
You have installed "ember-power-calendar" but you don't have any of the required meta-addons to make it work. Please, explicitly install 'ember-power-calendar-moment' or 'ember-power-calendar-luxon' in your app
```

This removes that error ¯\_(ツ)_/¯