### PR TITLE
Add option to use `ember-power-datepicker.scss`

### DIFF
--- a/ember-power-datepicker/_index.scss
+++ b/ember-power-datepicker/_index.scss
@@ -1,2 +1,1 @@
-@import "ember-basic-dropdown/_index.scss";
-@import "ember-power-calendar/_index.scss";
+@import "./ember-power-datepicker.scss";

--- a/ember-power-datepicker/ember-power-datepicker.scss
+++ b/ember-power-datepicker/ember-power-datepicker.scss
@@ -1,0 +1,2 @@
+@import "ember-basic-dropdown/_index.scss";
+@import "ember-power-calendar/_index.scss";

--- a/ember-power-datepicker/package.json
+++ b/ember-power-datepicker/package.json
@@ -16,11 +16,13 @@
     "./*": "./dist/*.js",
     "./addon-main.js": "./addon-main.cjs",
     "./ember-power-datepicker.less": "./ember-power-datepicker.less",
+    "./ember-power-datepicker.scss": "./ember-power-datepicker.scss",
     "./_index.scss": "./_index.scss"
   },
   "files": [
     "_index.scss",
     "ember-power-datepicker.less",
+    "ember-power-datepicker.scss",
     "addon-main.cjs",
     "declarations",
     "dist"


### PR DESCRIPTION
Add option for consumer apps to use import `@import 'ember-power-datepicker.scss'`

this works with `ember-cli-scss` only by adding `scssOptions`
```js
let app = new EmberApp(defaults, {
    ...
    sassOptions: {
      includePaths: ['node_modules/ember-power-datepicker'],
    },
    ...
  });
```

This was maybe working in older versions (without adding the setting `sassOptions`), but was not documented