### PR TITLE
Fix glint signature blocks

### DIFF
--- a/ember-power-datepicker/src/components/power-datepicker.ts
+++ b/ember-power-datepicker/src/components/power-datepicker.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import type {
   DropdownActions,
-  BasicDropdownSignature,
+  BasicDropdownDefaultBlock,
 } from 'ember-basic-dropdown/components/basic-dropdown';
 import type {
   CalculatePosition,
@@ -68,8 +68,8 @@ export interface PowerDatepickerCalendar {
 }
 
 export interface PowerDatepickerDefaultBlock extends PowerDatepickerCalendar {
-  Trigger: BasicDropdownSignature['Blocks']['default'][0]['Trigger'];
-  Content: BasicDropdownSignature['Blocks']['default'][0]['Content'];
+  Trigger: BasicDropdownDefaultBlock['Trigger'];
+  Content: BasicDropdownDefaultBlock['Content'];
   Nav: PowerCalendarDefaultBlock['Nav'];
   Days: PowerCalendarDefaultBlock['Days'];
 }

--- a/ember-power-datepicker/src/components/power-datepicker.ts
+++ b/ember-power-datepicker/src/components/power-datepicker.ts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import type { DropdownActions, BasicDropdownSignature } from 'ember-basic-dropdown/components/basic-dropdown';
+import type {
+  DropdownActions,
+  BasicDropdownSignature,
+} from 'ember-basic-dropdown/components/basic-dropdown';
 import type {
   CalculatePosition,
   VerticalPosition,
@@ -65,10 +68,10 @@ export interface PowerDatepickerCalendar {
 }
 
 export interface PowerDatepickerDefaultBlock extends PowerDatepickerCalendar {
-    Trigger:  BasicDropdownSignature['Blocks']['default'][0]['Trigger'];
-    Content: BasicDropdownSignature['Blocks']['default'][0]['Content'];
-    Nav: PowerCalendarDefaultBlock['Nav'];
-    Days: PowerCalendarDefaultBlock['Days'];
+  Trigger: BasicDropdownSignature['Blocks']['default'][0]['Trigger'];
+  Content: BasicDropdownSignature['Blocks']['default'][0]['Content'];
+  Nav: PowerCalendarDefaultBlock['Nav'];
+  Days: PowerCalendarDefaultBlock['Days'];
 }
 
 export default class PowerDatepickerComponent extends Component<PowerDatepickerSignature> {

--- a/ember-power-datepicker/src/components/power-datepicker.ts
+++ b/ember-power-datepicker/src/components/power-datepicker.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import type { DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
+import type { DropdownActions, BasicDropdownSignature } from 'ember-basic-dropdown/components/basic-dropdown';
 import type {
   CalculatePosition,
   VerticalPosition,
@@ -13,7 +13,7 @@ import type {
   SelectedDays,
   PowerCalendarActions,
 } from 'ember-power-calendar/components/power-calendar';
-import type { ComponentLike } from '@glint/template';
+import type { PowerCalendarDefaultBlock } from 'ember-power-calendar/components/power-calendar';
 
 interface PowerDatepickerSignature {
   Element: HTMLElement;
@@ -65,14 +65,10 @@ export interface PowerDatepickerCalendar {
 }
 
 export interface PowerDatepickerDefaultBlock extends PowerDatepickerCalendar {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Trigger: ComponentLike<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Content: ComponentLike<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Nav: ComponentLike<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Days: ComponentLike<any>;
+    Trigger:  BasicDropdownSignature['Blocks']['default'][0]['Trigger'];
+    Content: BasicDropdownSignature['Blocks']['default'][0]['Content'];
+    Nav: PowerCalendarDefaultBlock['Nav'];
+    Days: PowerCalendarDefaultBlock['Days'];
 }
 
 export default class PowerDatepickerComponent extends Component<PowerDatepickerSignature> {


### PR DESCRIPTION
This adapts the typing of the glint signature blocks using the typing of the sources that are yielded from, i.e. `basic-dropdown` and `power-calendar`.

This depends on two changes being merged/released: 
* https://github.com/cibernox/ember-basic-dropdown/pull/945
* https://github.com/cibernox/ember-power-calendar/pull/544