### PR TITLE
Remove ember-source and glimmer tracking as a peer dependency

### DIFF
--- a/ember-power-datepicker/package.json
+++ b/ember-power-datepicker/package.json
@@ -100,9 +100,7 @@
   },
   "peerDependencies": {
     "@glimmer/component": ">=1.1.2",
-    "@glimmer/tracking": "^1.1.2",
     "ember-basic-dropdown": "^8.6.0",
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
     "ember-power-calendar": "^1.5.2"
   },
   "publishConfig": {


### PR DESCRIPTION
- ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors
- @glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35